### PR TITLE
Fix a typo 80484->80486

### DIFF
--- a/MasmAssembly.tmLanguage
+++ b/MasmAssembly.tmLanguage
@@ -602,7 +602,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.80484</string>
+					<string>support.class.80486</string>
 				</dict>
 			</dict>
 			<key>comment</key>


### PR DESCRIPTION
Just as said in the title.

Actually I'm working on writing a syntax highlighting package for GoAsm, and used your project as a reference. Thank you for the great work. ;-)
